### PR TITLE
fix tautological-pointer-compare warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
 ExternalProject_Add(opencv2_src
   URL http://sourceforge.net/projects/opencvlibrary/files/opencv-unix/2.4.9/opencv-2.4.9.zip
   UPDATE_COMMAND ""
+  PATCH_COMMAND cd ../opencv2_src/ && patch -N modules/legacy/src/calibfilter.cpp ${CMAKE_CURRENT_SOURCE_DIR}/fix_warnings.patch
   CONFIGURE_COMMAND cd ../opencv2_src && cmake -D WITH_TBB=ON
     -DBUILD_NEW_PYTHON_SUPPORT=ON -D WITH_V4L=ON -D INSTALL_C_EXAMPLES=OFF
     -DINSTALL_PYTHON_EXAMPLES=OFF -D BUILD_EXAMPLES=OFF

--- a/fix_warnings.patch
+++ b/fix_warnings.patch
@@ -1,0 +1,24 @@
+--- /Users/slynen/catkin_ws/build/opencv2_catkin/opencv2_src-prefix/src/opencv2_src/modules/legacy/src/calibfilter.cpp	2014-04-11 12:15:26.000000000 +0200
++++ /Users/slynen/catkin_ws/build/opencv2_catkin/opencv2_src-prefix/src/opencv2_src/modules/legacy/src/calibfilter_patched.cpp	2014-10-20 01:06:08.000000000 +0200
+@@ -95,11 +95,8 @@
+ 
+     Stop();
+ 
+-    if (latestPoints != NULL)
+-    {
+-        for( i = 0; i < MAX_CAMERAS; i++ )
+-            cvFree( latestPoints + i );
+-    }
++    for( i = 0; i < MAX_CAMERAS; i++ )
++        cvFree( latestPoints + i );
+ 
+     if( type == CV_CALIB_ETALON_USER || type != etalonType )
+     {
+@@ -529,7 +526,6 @@
+         return;
+     }
+ 
+-    if( latestCounts )
+     {
+         for( i = 0; i < cameraCount; i++ )
+         {


### PR DESCRIPTION
Fixes Werror build failures caused by tautological-pointer-compares when building with a custom clang build on OSX.
